### PR TITLE
Trigger script after hardware setup in order to set light to booting state.

### DIFF
--- a/status_led_package.yaml
+++ b/status_led_package.yaml
@@ -15,10 +15,10 @@ globals:
 ##### CATCH SYSTEM EVENTS #####
 esphome:
   on_boot:
-    priority: -10
-    then:
-      - lambda: 'id(boot_done) = true;'
-      - script.execute: led_system_status
+    - priority: -10
+      then:
+        - lambda: 'id(boot_done) = true;'
+        - script.execute: led_system_status
 
 wifi:
   on_connect:

--- a/status_led_package.yaml
+++ b/status_led_package.yaml
@@ -15,7 +15,7 @@ globals:
 ##### CATCH SYSTEM EVENTS #####
 esphome:
   on_boot:
-    - priority: 800
+    - priority: 700
       then:
         - script.execute: led_system_status
     - priority: -10

--- a/status_led_package.yaml
+++ b/status_led_package.yaml
@@ -17,7 +17,10 @@ esphome:
   on_boot:
     - priority: -10
       then:
-        - lambda: 'id(boot_done) = true;'
+        - lambda: |
+            ESP_LOGD("status_led_package", "------ on boot -10 ------");
+            id(boot_done) = true;
+            ESP_LOGD("status_led_package", "boot_done = %s", id(boot_done) ? "true" : "false");
         - script.execute: led_system_status
 
 wifi:

--- a/status_led_package.yaml
+++ b/status_led_package.yaml
@@ -15,12 +15,12 @@ globals:
 ##### CATCH SYSTEM EVENTS #####
 esphome:
   on_boot:
+    - priority: 800
+      then:
+        - script.execute: led_system_status
     - priority: -10
       then:
-        - lambda: |
-            ESP_LOGD("status_led_package", "------ on boot -10 ------");
-            id(boot_done) = true;
-            ESP_LOGD("status_led_package", "boot_done = %s", id(boot_done) ? "true" : "false");
+        - lambda: 'id(boot_done) = true;'
         - script.execute: led_system_status
 
 wifi:


### PR DESCRIPTION
Without this, the light is off and switches immediately to `BOOT DONE (Priority 2) - yellow (fast pulse)` state.